### PR TITLE
Fix for the TypeBinaryExpressionNode

### DIFF
--- a/src/Serialize.Linq.Tests/ExpressionNodeTests.cs
+++ b/src/Serialize.Linq.Tests/ExpressionNodeTests.cs
@@ -121,7 +121,8 @@ namespace Serialize.Linq.Tests
             var expressionNode = factory.Create(expression);
             var createdExpression = expressionNode.ToExpression();
 
-            PublicInstancePropertiesAssert.AreEqual(expression, createdExpression, message);
+            Assert.AreEqual(expression.ToString(), createdExpression.ToString(), message);
+
             this.TestContext.WriteLine("'{0}' == '{1}'", expression.ToString(), createdExpression.ToString());
         }
     }

--- a/src/Serialize.Linq/Nodes/TypeBinaryExpressionNode.cs
+++ b/src/Serialize.Linq/Nodes/TypeBinaryExpressionNode.cs
@@ -28,14 +28,25 @@ namespace Serialize.Linq.Nodes
         #endregion
         public ExpressionNode Expression { get; set; }
 
+        #region DataMember
+#if !SERIALIZE_LINQ_OPTIMIZE_SIZE
+        [DataMember(EmitDefaultValue = false)]
+#else
+        [DataMember(EmitDefaultValue = false, Name = "O")]
+#endif
+        #endregion
+        public TypeNode TypeOperand { get; set; }
+
+
         protected override void Initialize(TypeBinaryExpression expression)
         {
             this.Expression = this.Factory.Create(expression.Expression);
+            this.TypeOperand = this.Factory.Create(expression.TypeOperand);
         }
 
         public override Expression ToExpression(ExpressionContext context)
         {
-            return System.Linq.Expressions.Expression.TypeIs(this.Expression.ToExpression(context), this.Type.ToType(context));
+            return System.Linq.Expressions.Expression.TypeIs(this.Expression.ToExpression(context), this.TypeOperand.ToType(context));
         }
     }
 }


### PR DESCRIPTION
- fix for the TypeBinaryExpressionNode: missing TypeOperand field was added;
- dirty fix for the AssertExpression helper method: call to the incorrectly implemented PublicInstancePropertiesAssert.AreEqual method was removed. Expressions string representations are compared instead.

For issue #15
