### PR TITLE
add support for ExpressionType.TypeEqual

### DIFF
--- a/src/Serialize.Linq.Tests/ExpressionNodeTests.cs
+++ b/src/Serialize.Linq.Tests/ExpressionNodeTests.cs
@@ -75,6 +75,7 @@ namespace Serialize.Linq.Tests
         public void SimpleTypeBinaryTest()
         {
             this.AssertExpression(Expression.TypeIs(Expression.Variable(this.GetType()), typeof(object)));
+            this.AssertExpression(Expression.TypeEqual(Expression.Variable(this.GetType()), typeof(object)));
         }        
 
         [TestMethod]

--- a/src/Serialize.Linq.Tests/Internals/ExpressionComparer.cs
+++ b/src/Serialize.Linq.Tests/Internals/ExpressionComparer.cs
@@ -67,7 +67,8 @@ namespace Serialize.Linq.Tests.Internals
                 case ExpressionType.ExclusiveOr:
                     return this.AreEqualBinary((BinaryExpression)x, (BinaryExpression)y);
                 case ExpressionType.TypeIs:
-                    return this.AreEqualTypeIs((TypeBinaryExpression)x, (TypeBinaryExpression)y);
+                case ExpressionType.TypeEqual:
+                    return this.AreEqualTypeBinary((TypeBinaryExpression)x, (TypeBinaryExpression)y);
                 case ExpressionType.Conditional:
                     return this.AreEqualConditional((ConditionalExpression)x, (ConditionalExpression)y);
                 case ExpressionType.Constant:
@@ -131,9 +132,10 @@ namespace Serialize.Linq.Tests.Internals
                 && this.AreEqual(x.Conversion, y.Conversion);
         }
 
-        protected virtual bool AreEqualTypeIs(TypeBinaryExpression x, TypeBinaryExpression y)
+        protected virtual bool AreEqualTypeBinary(TypeBinaryExpression x, TypeBinaryExpression y)
         {
-            return x.TypeOperand == y.TypeOperand
+            return x.NodeType == y.NodeType 
+                && x.TypeOperand == y.TypeOperand
                 && this.AreEqual(x.Expression, y.Expression);
         }
 

--- a/src/Serialize.Linq/Nodes/TypeBinaryExpressionNode.cs
+++ b/src/Serialize.Linq/Nodes/TypeBinaryExpressionNode.cs
@@ -58,7 +58,17 @@ namespace Serialize.Linq.Nodes
 
         public override Expression ToExpression(ExpressionContext context)
         {
-            return System.Linq.Expressions.Expression.TypeIs(this.Expression.ToExpression(context), this.TypeOperand.ToType(context));
+            switch (this.NodeType)
+            {
+                case ExpressionType.TypeIs:
+                    return System.Linq.Expressions.Expression.TypeIs(this.Expression.ToExpression(context), this.TypeOperand.ToType(context));
+                    
+                case ExpressionType.TypeEqual:
+                    return System.Linq.Expressions.Expression.TypeEqual(this.Expression.ToExpression(context), this.TypeOperand.ToType(context));
+                    
+                default:
+                    throw new NotSupportedException("unrecognised TypeBinaryExpression.NodeType " + Enum.GetName(typeof(ExpressionType), this.NodeType));
+            }
         }
     }
 }


### PR DESCRIPTION
TypeIs is not the only kind of TypeBinaryExpression node. TypeIs represents the c# "is" or vb "TypeOf..Is" operator, but there is also a TypeEqual node which represents an exact type equality check. foo TypeEqual Foo iff foo is an instance of Foo, not of subclasses.

There is no C# syntax which produces a TypeEqual node as far as I'm aware, but it works fine with linq2objects and has important use cases in a linq provider I maintain. This patch updates TypeBinaryExpressionNode.cs to support deserialising into a TypeEqual node, and updates the SimpleTypeBinaryTest.