### PR TITLE
Support Type constants

### DIFF
--- a/src/Serialize.Linq.Tests/ExpressionSerializerTests.cs
+++ b/src/Serialize.Linq.Tests/ExpressionSerializerTests.cs
@@ -200,6 +200,24 @@ namespace Serialize.Linq.Tests
             SerializeDeserializeExpressionAsBinary(CreateConstantDateTimeExpression(), new BinarySerializer());
         }
 
+        [TestMethod]
+        public void ExpressionWithConstantTypeAsJson()
+        {
+            SerializeDeserializeExpressionAsText(CreateConstantTypeExpression(), new JsonSerializer());
+        }
+
+        [TestMethod]
+        public void ExpressionWithConstantTypeAsXml()
+        {
+            SerializeDeserializeExpressionAsText(CreateConstantTypeExpression(), new XmlSerializer());
+        }
+
+        [TestMethod]
+        public void ExpressionWithConstantTypeAsBinary()
+        {
+            SerializeDeserializeExpressionAsBinary(CreateConstantTypeExpression(), new BinarySerializer());
+        }
+
         private static ConstantExpression CreateConstantDateTimeExpression()
         {
             return Expression.Constant(DateTime.Today);
@@ -209,6 +227,11 @@ namespace Serialize.Linq.Tests
         {
             var guidValue = Guid.NewGuid();
             return () => guidValue;
+        }
+
+        private static ConstantExpression CreateConstantTypeExpression()
+        {
+            return Expression.Constant(typeof(string));
         }
 
         private static Expression SerializeDeserializeExpressionAsText(Expression expression, ISerializer serializer)

--- a/src/Serialize.Linq/Nodes/ConstantExpressionNode.cs
+++ b/src/Serialize.Linq/Nodes/ConstantExpressionNode.cs
@@ -113,13 +113,18 @@ namespace Serialize.Linq.Nodes
             {
                 if (value is Expression)
                     throw new ArgumentException("Expression not allowed.", "value");
-                _value = value;
-                if (_value != null)
+
+                if (value is Type)
+                    _value = this.Factory.Create(value as Type);
+                else
+                    _value = value;
+
+                if (_value != null && !(_value is TypeNode))
                 {
                     var type = base.Type != null ? base.Type.ToType(new ExpressionContext()) : null;
                     if (type == null)
                     {
-                        if(this.Factory != null)
+                        if (this.Factory != null)
                             base.Type = this.Factory.Create(_value.GetType());
                         return;
                     }
@@ -144,7 +149,8 @@ namespace Serialize.Linq.Nodes
         /// <returns></returns>
         public override Expression ToExpression(ExpressionContext context)
         {
-            return this.Type != null ? Expression.Constant(this.Value, this.Type.ToType(context)) : Expression.Constant(this.Value);
+            return this.Value is TypeNode ? Expression.Constant((this.Value as TypeNode).ToType(context), this.Type.ToType(context)) : 
+                   this.Type != null ? Expression.Constant(this.Value, this.Type.ToType(context)) : Expression.Constant(this.Value);
         }
     }
 }


### PR DESCRIPTION
Code like `q.Where(x => x.GetType() == typeof(Foo)) ` produces expression trees containing a ConstantExpression with .Type = System.RuntimeType. These can be converted to and from ConstantExpressionNodes with .ToExpressionNode(), but currently the resulting ExpressionNode cannot be serialised.

The problem is that the DataContract serializer will encounter a polymorphic-typed value with runtime type System.RuntimeType. These can't be converted to json/xml/etc, and even if you fool it by using a monomorphic box, the resulting serialized text can't be deserialized as Activator.CreateInstance() also does not work on Type/RuntimeType.

This pull request enables serialization of these expressions by using a TypeNode internally, similar to how TypeBinaryNode does it. The Type is converted to a TypeNode when stored in ConstantExpressionNode.Value, and then resolved to a real Type in ToExpression().