### PR TITLE
Bug fix when a type has only 1 public field.

### DIFF
--- a/src/Serialize.Linq/Factories/TypeResolverNodeFactory.cs
+++ b/src/Serialize.Linq/Factories/TypeResolverNodeFactory.cs
@@ -102,7 +102,7 @@ namespace Serialize.Linq.Factories
                                             : constantValueType.GetFields(flags.Value);
                                         var memberField = fields.Length > 1
                                             ? fields.SingleOrDefault(n => field.Name.Equals(n.Name))
-                                            : fields.FirstOrDefault();
+                                            : fields.FirstOrDefault(n => field.Name.Equals(n.Name));
                                         if (memberField == null && parentField != null)
                                         {
                                             memberField = fields.Length > 1


### PR DESCRIPTION
When a type has only 1 public field and the field name has

- different from the name of the type that contains it then System.ArgumentException is generated at MethodCallExpressionNode ToExpression method

- the same name of the type that contains it, it is static, and it is instantiated then an infinite cycle occurs

I noticed this error when I would have used the Stream type.

What convention should I create tests (if it necessary) and where should I do it?

Thanks in advance for the reply!